### PR TITLE
正規ホストを www 付きからルートドメインへ変更する

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -6,7 +6,11 @@ const siteMetadata = {
   description: '本とアニメと音楽について',
   language: 'ja',
   theme: 'dark', // system, dark or light
-  siteUrl: 'https://www.reiji990.blog',
+  // Cloudflare 移行に伴い正規ホストを www 付きからルートドメインへ変更した。
+  // canonical / sitemap / robots / RSS / JSON-LD / OG はすべてこの値から導出されるため、
+  // ここを変えないと正規 URL がリダイレクト先を指すことになり検索評価が分散する。
+  // www.reiji990.blog は Cloudflare の Redirect Rule で 301 させること。
+  siteUrl: 'https://reiji990.blog',
   siteRepo: 'https://github.com/reiji990/blog',
   siteLogo: '/static/images/logo.png',
   socialBanner: '/static/images/twitter-card.png',


### PR DESCRIPTION
Cloudflare 移行に合わせて本番を reiji990.blog に切り替えたため、
siteUrl を追従させる。この値は canonical / sitemap / robots.txt / RSS / JSON-LD / OG url のすべての導出元になっており、変更しないと
正規 URL が 301 先を指す状態になって検索評価が分散する。

ビルド出力で確認済み:
  canonical  https://reiji990.blog/blog/watanare02
  robots     Host: https://reiji990.blog
  sitemap    <loc>https://reiji990.blog/</loc>
  RSS        https://reiji990.blog/blog
  og:url     https://reiji990.blog/blog/watanare02
出力全体から www.reiji990.blog は消えた (該当ファイル 0 件)。

www.reiji990.blog は Cloudflare の Redirect Rule で 301 させる。